### PR TITLE
docmented explaining 'ubicacion' entity

### DIFF
--- a/src/main/java/com/example/demo/Entity/Ubicacion.java
+++ b/src/main/java/com/example/demo/Entity/Ubicacion.java
@@ -16,6 +16,14 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import java.util.List;
 
+/**
+ * Represents the entity of a location (Ubicacion) in the system.
+ * <p>
+ *     This class maps location information to the 'ubicacion' table in the database.
+ *     It includes address data, neighborhood data, and a relationship to the {@link Ciudad} entity.
+ *     It also has a one-to-many relationship to the {@link Usuario} entity.
+ * </p>
+ * */
 @Entity
 @Table(name = "ubicacion")
 @Data
@@ -23,23 +31,50 @@ import java.util.List;
 @AllArgsConstructor
 public class Ubicacion {
 
+    /**
+     * The unique identifier for the location.
+     * Mapped as the primary key of the 'Ubicacion' table with auto-increment.
+     * */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id_ubicacion")
     private Integer idUbicacion;
 
+    /**
+     * The name of the location`s neighborhood(barrio)
+     * This is a required field and has a maximum length of 100 characters.
+     * */
     @Column(name = "barrio", nullable = false, length = 100)
     private String barrio;
 
+    /**
+     * The full address of the location.
+     * This is a required field and has a maximum length of 255 characters.
+     * */
     @Column(name = "direccion", nullable = false, length = 255)
     private String direccion;
 
-    // Relación ManyToOne con Ciudad
+    /**
+     * The city to which the location belongs.
+     * <p>
+     *     Establishes a many-to-one relationship with the {@link Ciudad} entity.
+     *     lazy-loaded to optimize performance.
+     * </p>
+     * */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_ciudad", referencedColumnName = "id_ciudad")
     private Ciudad ciudad;
 
-    // Si una Ubicacion puede tener MUCHOS Usuarios (OneToMany):
+    /**
+     * The list of users located at this location.
+     * <p>
+     *     Establishes a one-to-many relationship with the {@link Usuario} entity.
+     *     The 'mappedBy' attribute indicates that the relationship is managed by the 'Ubicacion' field
+     *     in the 'usuario' class.
+     *     'CascadeType.ALL' is used to propagate persistence operations.
+     *     lazy-loaded to optimize performance.
+     * </p>
+     * */
     @OneToMany(mappedBy = "ubicacion", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Usuario> usuarios;
 }

--- a/src/main/java/com/example/demo/Entity/Usuario.java
+++ b/src/main/java/com/example/demo/Entity/Usuario.java
@@ -14,7 +14,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Represent the entity of a user en the system.
+ * Represents the entity of a user (Usuario) in the system.
  * <p>
  *     This class mapeo the information at the users the table 'usuario' in the database.
  *     Included personal data such as name and telephone number, and relationships with entities.
@@ -29,8 +29,8 @@ import lombok.NoArgsConstructor;
 public class Usuario {
 
     /**
-     * El identificador único del usuario.
-     * Mapeado como la clave primaria de la tabla 'usuario' con auto incremento.
+     * The user's unique identifier.
+     * Mapped as the primary key of the 'user' table with auto increment.
      * */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,26 +38,26 @@ public class Usuario {
     private Integer idUsuario;
 
     /**
-     * El nombre completo del usuario.
-     * Es un campo obligatorio y tiene una longitud máxima de 100 caracteres.
+     * The user's full name.
+     * This is a required field and has a maximum length of 100 characters.
      * */
     @Column(name = "nombre", nullable = false, length = 100)
     private String nombre;
 
     /**
-     * El número de teléfono del usuario.
-     * Es un campo opcional.
+     * The user's phone number.
+     * It is an optional field.
      * */
     @Column(name = "telefono", length = 20)
     private String telefono;
 
-    // Relaciones de Clave Foránea (FKs)
+    // Foreign key relationships (FKs)
 
     /**
-     * La comunidad a la comunidad a la que pertenece el usuario.
+     * The community to witch the user.
      * <p>
-     *     Establece una relación de muchos-a-uno (ManyToOne) con la entidad {@link Comunidad}.
-     *     Se carga de forma (Lazy) para optimizar el rendimiento.
+     *     Establishes a many-to-one relationship with the {@link Comunidad} entity.
+     *     Lazy loading to optimize performance.
      * </p>
      * */
     @ManyToOne(fetch = FetchType.LAZY)
@@ -65,10 +65,10 @@ public class Usuario {
     private Comunidad comunidad;
 
     /**
-     * La ubicación del usuario.
+     * The user's location.
      * <P>
-     *     Establece una relación de muchos-a-uno (ManyToOne) con la entidad {@link Ubicacion}.
-     *     También se carga de forma (Lazy) para optimizar el rendimiento.
+     *     Establishes a many-to-one relationship with the {@link Ubicacion} entity.
+     *     It also loads lazily to optimize performance.
      * </P>
      * */
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
The 'Ubicacion' entity is documented, explaining the table's attributes, such as 'id', 'barrio', 'direccion', and their foreign keys and relationships.
The 'user' entity documentation is provided in English.